### PR TITLE
Poprawka dla tworzenia podstron

### DIFF
--- a/scripts/main_page_frame.js
+++ b/scripts/main_page_frame.js
@@ -13,6 +13,8 @@ function addNewTile(event) {
     var title = document.getElementById("title").value;
     var description = document.getElementById("description").value;
 
+    window.parent.postMessage({type: 'subpage', page: title}, '*');
+    
     var newTile = document.createElement("div");
 
     newTile.addEventListener('click', function() {

--- a/scripts/script.js
+++ b/scripts/script.js
@@ -103,8 +103,8 @@ window.addEventListener('message', function(event) {
 
             var cotainer = document.getElementById('main-content');
             cotainer.appendChild(nowyPokoj);
+        } else {
+            showSubpage(event.data.page);
         }
-
-        showSubpage(event.data.page);
     }
 });

--- a/styles/index_page.css
+++ b/styles/index_page.css
@@ -121,6 +121,7 @@ body, html {
 
 .side-bar {
     background-color: #555454;
+    margin-bottom: -47px;
 }
 
 .container {


### PR DESCRIPTION
1. Tworząc kafelek pomieszczenia tworzyło faktyczną podstronę oraz jego odpowiednik na pasku bocznym.

2. Tworząc kafelek nie przerzuca już na podstronę tego pomieszczenia.